### PR TITLE
elastic search passage id 기반 유사문항 조회 기능 추가

### DIFF
--- a/src/main/java/com/pullit/item/elastic/controller/ItemController.java
+++ b/src/main/java/com/pullit/item/elastic/controller/ItemController.java
@@ -32,6 +32,7 @@ public class ItemController {
         List<ItemImageDocument> similarItems = itemImageService.findSimilarItems(
                 request.getTopicChapterId(),
                 request.getDifficultyCode(),
+                request.getPassageId(),
                 request.getExcludeItemIds(),
                 request.getSize()
         );
@@ -45,6 +46,7 @@ public class ItemController {
     public static class SimilarItemsRequest {
         private long topicChapterId;
         private int difficultyCode;
+        private long passageId = -1;
         private List<Long> excludeItemIds = new ArrayList<>();
         private int size = 20;
     }

--- a/src/main/java/com/pullit/item/elastic/document/ItemImageDocument.java
+++ b/src/main/java/com/pullit/item/elastic/document/ItemImageDocument.java
@@ -22,6 +22,9 @@ public class ItemImageDocument implements JsonpSerializable {
     @JsonProperty("item_id")
     private Long itemId;
 
+    @JsonProperty("passage_id")
+    private Long passageId;
+
     @JsonProperty("passage_url")
     private String passageUrl;
 
@@ -56,6 +59,7 @@ public class ItemImageDocument implements JsonpSerializable {
     public void serialize(JsonGenerator jsonGenerator, JsonpMapper jsonpMapper) {
         jsonGenerator.writeStartObject();
         if (itemId != null) { jsonGenerator.write("item_id", itemId); }
+        if (passageId != null) { jsonGenerator.write("passage_id", passageId); }
         if (passageUrl != null) { jsonGenerator.write("passage_url", passageUrl); }
         if (questionUrl != null) { jsonGenerator.write("question_url", questionUrl); }
         if (answerUrl != null) { jsonGenerator.write("answer_url", answerUrl); }
@@ -74,6 +78,7 @@ public class ItemImageDocument implements JsonpSerializable {
 
     protected static void setupItemImageDocumentDeserializer(ObjectDeserializer<ItemImageDocument.Builder> op) {
         op.add(Builder::itemId, JsonpDeserializer.longDeserializer(), "item_id");
+        op.add(Builder::passageId, JsonpDeserializer.longDeserializer(), "passage_id");
         op.add(Builder::passageUrl, JsonpDeserializer.stringDeserializer(), "passage_url");
         op.add(Builder::questionUrl, JsonpDeserializer.stringDeserializer(), "question_url");
         op.add(Builder::answerUrl, JsonpDeserializer.stringDeserializer(), "answer_url");
@@ -88,6 +93,7 @@ public class ItemImageDocument implements JsonpSerializable {
 
     public static class Builder implements ObjectBuilder<ItemImageDocument> {
         private Long itemId;
+        private Long passageId;
         private String passageUrl;
         private String questionUrl;
         private String answerUrl;
@@ -103,6 +109,12 @@ public class ItemImageDocument implements JsonpSerializable {
             this.itemId = itemId;
             return this;
         }
+
+        public Builder passageId(Long passageId) {
+            this.passageId = passageId;
+            return this;
+        }
+
         public Builder passageUrl(String passageUrl) {
             this.passageUrl = passageUrl;
             return this;
@@ -147,6 +159,7 @@ public class ItemImageDocument implements JsonpSerializable {
         public ItemImageDocument build() {
             return new ItemImageDocument(
                     itemId,
+                    passageId,
                     passageUrl,
                     questionUrl,
                     answerUrl,

--- a/src/main/java/com/pullit/item/elastic/service/ItemImageService.java
+++ b/src/main/java/com/pullit/item/elastic/service/ItemImageService.java
@@ -28,6 +28,7 @@ public class ItemImageService {
     public List<ItemImageDocument> findSimilarItems(
             long topicChapterId,
             int difficultyCode,
+            long passageId,
             List<Long> excludeItemIds,
             int size
     ) throws IOException {
@@ -38,10 +39,19 @@ public class ItemImageService {
         long mediumChapterId = truncateCode(topicChapterId, 8);
         long smallChapterId = truncateCode(topicChapterId, 10);
 
-        // 기본 필터: 난이도 동일, 제외 문항 제외
+        // 기본 필터: 난이도 동일
         BoolQuery.Builder baseBoolQuery = new BoolQuery.Builder()
                 .must(m -> m.term(t -> t.field("difficulty_code").value(difficultyCode)));
 
+        // 지문 id 동일
+        if (passageId != -1) {
+            baseBoolQuery.must(mn -> mn.term(t -> t
+                    .field("passage_id")
+                    .value(passageId)
+            ));
+        }
+
+        // 제외 문항 제외
         if (excludeItemIds != null && !excludeItemIds.isEmpty()) {
             baseBoolQuery.mustNot(mn -> mn.terms(t -> t
                     .field("item_id")


### PR DESCRIPTION
## 연결된 이슈
<!-- 이 PR이 닫을 이슈 번호를 적어주세요. 예: closes #12 -->
closes #126 

---

## 요약 (Summary)

elastic search passage id 기반 유사 문항 조회 기능 추가

---

## 작업 상세 내용 (Checklist)

- [ ] TODO 1
- [ ] TODO 2
- [ ] TODO 3

---

## 스크린샷 / 시연 (선택)

<!-- UI 변경이 있거나 확인이 필요한 경우 이미지나 GIF를 첨부해주세요 -->

---

## 리뷰어에게 공유할 내용 (선택)

<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이나, 논의하고 싶은 사항이 있다면 작성해주세요 -->

---

## PR 체크리스트

- [ ] 커밋 메시지가 적절한지 확인했어요 (`feat`, `fix` 등)
- [ ] 이슈 번호를 연결했어요 (`closes #`)
- [ ] 기능/버그가 정상 작동하는지 테스트했어요
